### PR TITLE
Fix build under vs2015 by using safe func (_s)

### DIFF
--- a/SXWindows/HashUtils.h
+++ b/SXWindows/HashUtils.h
@@ -41,7 +41,7 @@ public:
  	}
 	static sxbyte numToHex(char c) {
 		char buffer[2];
-		sprintf(buffer, "%x", c);
+		sprintf_s(buffer, "%x", c);
 		return buffer[0];
 	}
 };

--- a/SXWindows/VpnUtils.h
+++ b/SXWindows/VpnUtils.h
@@ -21,8 +21,8 @@ public:
 		pras->dwRedialPause = 60;
 		pras->dwfNetProtocols = RASNP_Ip;
 		pras->dwEncryptionType = ET_Optional;
-		strcpy(pras->szLocalPhoneNumber, server.c_str());
-		strcpy(pras->szDeviceType, RASDT_Vpn);
+		strcpy_s(pras->szLocalPhoneNumber, server.c_str());
+		strcpy_s(pras->szDeviceType, RASDT_Vpn);
 		pras->dwfOptions = RASEO_RemoteDefaultGateway;
 
 		pras->dwVpnStrategy = VS_L2tpOnly;
@@ -35,8 +35,8 @@ public:
 
   		char *uname = HashUtil::vecToChar(username);
 
-		strcpy(ras_cre.szUserName, uname);
-		strcpy(ras_cre.szPassword, passwd.c_str());
+		strcpy_s(ras_cre.szUserName, uname);
+		strcpy_s(ras_cre.szPassword, passwd.c_str());
 		RasSetCredentials(NULL, name.c_str(), &ras_cre, FALSE);
 
 		// Dial a RAS entry in synchronous mode
@@ -48,9 +48,9 @@ public:
 		memset(&rasDialParams, 0, sizeof(RASDIALPARAMS));
 
 		rasDialParams.dwSize = sizeof(RASDIALPARAMS);
-		strcpy(rasDialParams.szEntryName, name.c_str());
-		strcpy(rasDialParams.szUserName, uname);
-		strcpy(rasDialParams.szPassword, passwd.c_str());
+		strcpy_s(rasDialParams.szEntryName, name.c_str());
+		strcpy_s(rasDialParams.szUserName, uname);
+		strcpy_s(rasDialParams.szPassword, passwd.c_str());
 
 		if (RasDial(NULL, NULL, &rasDialParams, 0, NULL, &hRasConn)
 			!= 0) {


### PR DESCRIPTION
Fix build under vs2015 by using safe func (_s), e.g. `strcpy_s`, `sprintf_s`.

This commit will fix build error like this (the `error` lines):
![image](https://cloud.githubusercontent.com/assets/4176091/14586834/1851f91e-04d8-11e6-8772-06f0a2cf5bc0.png)
